### PR TITLE
feat(kagi): KagiのSummarizerを追加して両方のタブを開く機能を実装

### DIFF
--- a/kagi/open_kagi-assistant_with_query.user.js
+++ b/kagi/open_kagi-assistant_with_query.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name         Open Kagi Assistant with Query
-// @version      2025-04-20
-// @description  Kagi Assistant に query パラメータで現在いるページの URL を引き渡し、要約を開始する
+// @name         Open Kagi Assistant / Summarizer with Query
+// @version      2025-04-21
+// @description  Kagi Assistant / summarizer に query パラメータで現在いるページの URL を引き渡し、要約を開始する
 // @author       Hokuto TAKEMIYA
 // @match        *://*/*
 // @grant        GM_openInTab
@@ -11,12 +11,14 @@
     'use strict';
 
     const currentUrl = window.location.href;
+    const summarizerUrl = `https://kagi.com/summarizer/index.html?target_language=JA&summary=takeaway&url=${encodeURIComponent(currentUrl)}`;
     const query = `下記のURLのページを確認し、小見出しと箇条書きを活用してキーセンテンスを作成ください。この後内容についてディスカッションしましょう。\n${currentUrl}`;
     const assistantUrl = `https://kagi.com/assistant?q=${encodeURIComponent(query)}&internet=true`;
     document.addEventListener('keydown', function(event) {
         // Alt + Shift + Z が押されたかチェック
         if (event.altKey && event.shiftKey && event.code === 'KeyZ') {
             // ここに実行したい処理を書く
+            GM_openInTab(summarizerUrl, { active: false });
             GM_openInTab(assistantUrl, { active: true });
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
- Userスクリプト名と説明を更新し、"Summarizer"を含めるようにした
- Kagiの要約機能用の新しいURLを追加
- Alt+Shift+Z押下時に要約ツールも同時に開くよう機能追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Alt+Shift+Zキーで、Kagiのサマライザーページ（日本語・要点モード）をバックグラウンドタブで開き、続けてアシスタントページをアクティブタブで開くようになりました。

- **その他**
  - スクリプト名、バージョン、説明文が更新され、サマライザー対応が明記されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->