### PR TITLE
feat(query): ウェブページアクセス不可時の対応指示を追加

### DIFF
--- a/gemini/open_gemini_with_query.user.js
+++ b/gemini/open_gemini_with_query.user.js
@@ -11,7 +11,13 @@
     'use strict';
 
     const currentUrl = window.location.href;
-    const query = `下記のURLのページを確認し、小見出しと箇条書きを活用してキーセンテンスを作成ください。この後内容についてディスカッションしましょう。\n${currentUrl}`;
+    const query = `下記のURLのページを確認し、小見出しと箇条書きを活用してキーセンテンスを作成ください。
+この後内容についてディスカッションしましょう。
+${currentUrl}
+
+## 注意事項
+WEBページにアクセス出来ない場合もあります。
+その場合は「WEBページにアクセス出来ませんでした」と返答する決まりとなっています`;
     const assistantUrl = `https://gemini.google.com/app?query=${encodeURIComponent(query)}`;
     document.addEventListener('keydown', function(event) {
         // Alt + Shift + S が押されたかチェック

--- a/gemini/open_gemini_with_query.user.js
+++ b/gemini/open_gemini_with_query.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Open Gemini with Query
-// @version      2025-04-06
+// @version      2025-04-21
 // @description  Gemini に query パラメータで現在いるページの URL を引き渡す
 // @author       Hokuto TAKEMIYA
 // @match        *://*/*

--- a/kagi/open_kagi-assistant_with_query.user.js
+++ b/kagi/open_kagi-assistant_with_query.user.js
@@ -12,7 +12,13 @@
 
     const currentUrl = window.location.href;
     const summarizerUrl = `https://kagi.com/summarizer/index.html?target_language=JA&summary=takeaway&url=${encodeURIComponent(currentUrl)}`;
-    const query = `下記のURLのページを確認し、小見出しと箇条書きを活用してキーセンテンスを作成ください。この後内容についてディスカッションしましょう。\n${currentUrl}`;
+    const query = `下記のURLのページを確認し、小見出しと箇条書きを活用してキーセンテンスを作成ください。
+この後内容についてディスカッションしましょう。
+${currentUrl}
+
+## 注意事項
+WEBページにアクセス出来ない場合もあります。
+その場合は「WEBページにアクセス出来ませんでした」と返答する決まりとなっています`;
     const assistantUrl = `https://kagi.com/assistant?q=${encodeURIComponent(query)}&internet=true`;
     document.addEventListener('keydown', function(event) {
         // Alt + Shift + Z が押されたかチェック


### PR DESCRIPTION
- Gemini と Kagi の両方のクエリに注意事項セクションを追加
- ウェブページにアクセスできない場合の応答指示を明確化
- クエリテキストを複数行に分割して可読性を向上

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GeminiおよびKagi Assistantに送信されるクエリ内容が拡張され、見出しや箇条書きを用いた要約作成の指示や、ページにアクセスできない場合の応答方法が明記されました。  
- **改善**
  - ページが閲覧できないケースへの対応が明確化され、ユーザーへの案内がより分かりやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->